### PR TITLE
Add option to skip building Tcl/Tk

### DIFF
--- a/buildall.py
+++ b/buildall.py
@@ -14,17 +14,22 @@ def main(options):
 
     shutil.copy(os.path.join(utils.DEPSSRC, 'stdint.h'), os.path.join(utils.config_dir(), 'stdint.h'))
 
+    libs = []
     if 'LIB' in os.environ:
-        os.environ['LIB'] = '{};{}'.format(os.environ['LIB'], utils.config_dir())
-    else:
-        os.environ['LIB'] = utils.config_dir()
+        libs.append(os.environ['LIB'])
+    libs.append(utils.config_dir())
+    if not options.no_tcl:
+        # tcl lib comes with python install
+        libs.append(os.path.join(os.path.dirname(sys.executable), 'tcl'))
+    os.environ['LIB'] = ';'.join(libs)
 
-    os.environ['LIB'] = '{};{}'.format(os.environ['LIB'], os.path.join(os.path.dirname(sys.executable), 'tcl'))
-
+    includes = []
     if 'INCLUDE' in os.environ:
-        os.environ['INCLUDE'] = '{};{};{}'.format(os.environ['INCLUDE'], utils.config_dir(), utils.tcl_config_dir())
-    else:
-        os.environ['INCLUDE'] = '{};{}'.format(utils.config_dir(), utils.tcl_config_dir())
+        includes.append(os.environ['INCLUDE'])
+    includes.append(utils.config_dir())
+    if not options.no_tcl:
+        includes.append(utils.tcl_config_dir())
+    os.environ['INCLUDE'] = ';'.join(includes)
 
     os.chdir(options.mpl_dir)
 
@@ -45,7 +50,9 @@ if __name__ == '__main__':
     parser.add_option('--setup_cmd', '-s', action="store", dest="setup_cmd",
                                            default="install", help="Command to pass to setup.py")
     parser.add_option('--no_tcl', '-n', action="store_true", dest="no_tcl",
-                                          default=False, help="Don't build Tcl/Tk (for headless MPL servers)")
+                                          default=False, help="Don't build Tcl/Tk (for headless MPL servers); "
+                                                              "MPL build process will discover Tcl/Tk support "
+                                                              "if installed elsewhere on your system")
     options, rem = parser.parse_args()
 
     main(options)

--- a/buildall.py
+++ b/buildall.py
@@ -6,7 +6,8 @@ import optparse
 
 
 def main(options):
-    utils.build_tcl()
+    if not options.no_tcl:
+        utils.build_tcl()
     utils.build_zlib()
     utils.build_libpng()
     utils.build_freetype()
@@ -43,6 +44,8 @@ if __name__ == '__main__':
                                           default=default_path, help="Matplotlib repo directory")
     parser.add_option('--setup_cmd', '-s', action="store", dest="setup_cmd",
                                            default="install", help="Command to pass to setup.py")
+    parser.add_option('--no_tcl', '-n', action="store_true", dest="no_tcl",
+                                          default=False, help="Don't build Tcl/Tk (for headless MPL servers)")
     options, rem = parser.parse_args()
 
     main(options)

--- a/utils.py
+++ b/utils.py
@@ -121,7 +121,7 @@ copy /Y /B zconf.h %INCLIB%
 def build_zlib():
     inclib = config_dir()
     if not os.path.exists(inclib):
-        os.mkdir(inclib)
+        os.makedirs(inclib)
 
     distfile = os.path.join(DEPSSRC, 'zlib128.zip')
     compfile = os.path.join(inclib, 'z.lib')


### PR DESCRIPTION
When building a program which doesn't use a GUI, it's sometimes useful to avoid including Tcl/Tk entirely.  This makes the program smaller for distribution when using e.g. PyInstaller, and has the side benefit of not pulling in additional GUI-related DLLs.

This PR simply adds an option to skip building Tcl/Tk.  Tested with MPL 1.3.1 and 1.4.2, Windows 7, 32-bit Python 2.7.8.
