### PR TITLE
force utf-8 encoding

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -31,10 +31,10 @@ def fixproj(project_file, bit_target):
     """
     :param bit_target: one of 'Win32' or 'x64'
     """
-    with open(project_file, 'r') as fd:
+    with open(project_file, 'r', encoding='utf-8') as fd:
         content = '\n'.join(line.strip() for line in fd if line.strip())
     content = content.replace('Win32', bit_target).replace('x64', bit_target)
-    with open(project_file, 'w') as fd:
+    with open(project_file, 'w', encoding='utf-8') as fd:
         fd.write(content)
 
 def tar_extract(tar_file, target):


### PR DESCRIPTION
Needed to force 'utf-8' encoding, otherwise it would throw an exception on my machine:
```
Traceback (most recent call last):
  File "buildall.py", line 58, in <module>
    main(options)
  File "buildall.py", line 13, in main
    utils.build_freetype()
  File "C:\Users\davidhcefx\matplotlib-winbuild\utils.py", line 225, in build_freetype
    fixproj(os.path.join(ft_dir, 'builds', 'win32', vc, 'freetype.sln'), WinXX)
  File "C:\Users\davidhcefx\matplotlib-winbuild\utils.py", line 44, in fixproj
    fd.write(content)
UnicodeEncodeError: 'cp950' codec can't encode character '\ufeff' in position 0: illegal multibyte sequence
```

### As well as others': https://github.com/jbmohler/matplotlib-winbuild/issues/6